### PR TITLE
Enable UI only load statistics for specified report period.

### DIFF
--- a/config.js.template
+++ b/config.js.template
@@ -4,19 +4,34 @@ var consoleReporter = require("./reporters/consoleReporter");
 module.exports = {
 	apiUrl: "github_url",
 	defaultBranch: "master",
+	store: {
+		url: "localhost",
+		db: "contribcat"
+	},
+	caching: true,
 	repos: [
 		"organisation/repo:branch"
 	],
 	plugins: [
 		score({
 			"weighting": {
-				"for": 5,
-				"against": -1
+				"for": {
+					"issue": 3,
+					"diff": 5
+				},
+				"against": {
+					"issue": 1,
+					"diff": 2
+				},
+				"sentiment": 1,
+				"pr": 10
 			}
 		})
 	],
 	reporters: [
 		consoleReporter()
 	],
-	days: 90
-}
+	pageSize: 20,
+	syncDays: 90,
+	reportDays: 365
+};

--- a/models/Comment.js
+++ b/models/Comment.js
@@ -15,8 +15,8 @@ var Comment = mongoose.model("Comment", new Schema({
 	"line": Number,
 	"path": String,
 	"commit_id": String,
-	"created_at": String,
-	"updated_at": String,
+	"created_at": Date,
+	"updated_at": Date,
 	"body": String
 }));
 

--- a/site/server.js
+++ b/site/server.js
@@ -37,7 +37,7 @@ app.engine("html", nunjucks.render);
 app.set("view engine", "html");
 
 app.get("/user/:username", (req, res) => {
-	contribCat.getUser(req.params.username).then(contribCat.runPlugins.bind(contribCat)).then((results) => {
+	contribCat.getUserStatistics(req.query.days, req.params.username).then(contribCat.runPlugins.bind(contribCat)).then((results) => {
 		res.render('index.html', {
 			user: results.users[0]
 		});
@@ -45,7 +45,9 @@ app.get("/user/:username", (req, res) => {
 });
 
 app.get("/overview", (req, res) => {
-	contribCat.run().then((results) => {
+	contribCat.getUserStatistics(req.query.days)
+		.then(contribCat.runPlugins.bind(contribCat))
+		.then((results) => {
 		results.users.sort(function (a, b) {
 			if (a.kudos > b.kudos) {
 				return 1;


### PR DESCRIPTION
- Enhancements to prevent duplicate Prs & Comments being attached to a user
- Extra configuration (syncDays, reportDays, caching, store, pageSize)
- Extend `getUsers` to only return statistics for the report period
